### PR TITLE
Update accessibility based on boxmenu

### DIFF
--- a/templates/cover-item.hbs
+++ b/templates/cover-item.hbs
@@ -1,15 +1,17 @@
-<div class="menu-item-inner" role="menuitem">
-	<div class="menu-item-title" role="heading">
-		<h2 class="menu-item-title-inner">{{{title}}}</h2>
+<div class="menu-item-inner" role="menuitem" aria-label="{{_globals._menu._coverMenu.menuItem}}" {{#if _globals._menu._coverMenu.menuItem}}tabindex="0"{{/if}}>
+    <div class="menu-item-title">
+        <div class="menu-item-title-inner h3 accessible-text-block" role="heading" aria-level="2" tabindex="0">{{{displayTitle}}}</div>
 	</div>
 	<div class="menu-item-body">
-		<div class="menu-item-body-inner">{{{body}}}</div>
+		<div class="menu-item-body-inner">{{{a11y_text body}}}</div>
 	</div>
+    {{#if duration}}
 	<div class="menu-item-duration">
-		<div class="menu-item-duration-inner">Duration: {{{duration}}}</div>
+		<div class="menu-item-duration-inner accessible-text-block" role="region" tabindex="0">{{#if _globals._menu._coverMenu.durationLabel}}{{{_globals._menu._coverMenu.durationLabel}}}{{/if}} {{{duration}}}</div>
 	</div>
+    {{/if}}
 	{{#unless _isLocked}}
-	<a class="menu-item-route button" href="#/id/{{_id}}" class="{{#if _isVisited}}visited{{/if}}" aria-label="{{_coverMenu_ariaLabels.menuViewButton}}">
+	<a class="menu-item-route button {{#if _isVisited}}visited{{/if}} accessible-text-block" href="#/id/{{_id}}" aria-label="{{_coverMenu_ariaLabels.menuViewButton}}">
 		{{{linkText}}}
 	</a>
 	{{/unless}}

--- a/templates/cover.hbs
+++ b/templates/cover.hbs
@@ -1,17 +1,17 @@
-<div class="menu-container" role="region">
+<div class="menu-container" role="region" aria-label="{{_globals._menu._coverMenu.ariaRegion}}">
 	<div class="menu-intro-screen">
 		<div class="menu-intro-screen-inner">
-			{{#if title}}
-			<div class="menu-title" role="heading">
-				<h1 class="menu-title-inner">
-					{{{title}}}
-				</h1>
+            {{#if displayTitle}}
+            <div class="menu-title">
+                    <div class="menu-title-inner h1 accessible-text-block" role="heading" aria-level="1" tabindex="0">
+                        {{{displayTitle}}}
+                    </div>
 			</div>
 			{{/if}}
 			{{#if body}}
-			<div class="menu-body">
-				<div class="menu-body-inner">
-					{{{body}}}
+                <div class="menu-body">
+                    <div class="menu-body-inner accessible-text-block">
+                        {{{a11y_text body}}}
 				</div>
 			</div>
 			{{/if}}


### PR DESCRIPTION
I updated accessibility based on adapt-contrib-boxmenu. 
An oddball: &lt;a class="menu-item-route button"&gt; (a) It had two "class" attributes; I consolidated them. (b) boxmenu uses <button> instead of <a>; however, adapt-cover-extensions.js references ".menu-item-route" as a selector, so I thought it best not to convert it at this time.
